### PR TITLE
Remove client user id (formerly years of experience) validation

### DIFF
--- a/application/modules/default/forms/Experiencedetails.php
+++ b/application/modules/default/forms/Experiencedetails.php
@@ -130,10 +130,10 @@ class Default_Form_Experiencedetails extends Zend_Form
 		$reference_contact = new Zend_Form_Element_Text('reference_contact');
         $reference_contact->addFilter(new Zend_Filter_StringTrim());
         $reference_contact->setRequired(true);
-		$reference_contact->setAttrib("maxlength",10);
+		$reference_contact->setAttrib("maxlength",15);
         $reference_contact->addValidator('NotEmpty', false, array('messages' => 'Please enter referrer contact.'));
 		$reference_contact->addValidators(array(array('StringLength',false,
-									  array('min' => 10,
+									  array('min' => 9,
 											'max' => 10,
 											'messages' => array(
 											Zend_Validate_StringLength::TOO_LONG =>

--- a/application/modules/default/forms/Myteamemployee.php
+++ b/application/modules/default/forms/Myteamemployee.php
@@ -214,11 +214,6 @@ class Default_Form_Myteamemployee extends Zend_Form
 		$yearsofexp = new Zend_Form_Element_Text('years_exp');
 		$yearsofexp->setAttrib('maxLength', 10);
 		$yearsofexp->addFilter(new Zend_Filter_StringTrim());
-		$yearsofexp->addValidator("regex",true,array(
-							 'pattern'=>'/^(0|[1-9][0-9]*)$/', 
-							  'messages' => array('regexNotMatch'=>'Please enter only numbers.'
-                           )
-        	));
 		
 		$extension_number = new Zend_Form_Element_Text('extension_number');
 		$extension_number->setAttrib('maxLength', 10);

--- a/application/modules/default/forms/employee.php
+++ b/application/modules/default/forms/employee.php
@@ -174,12 +174,6 @@ class Default_Form_employee extends Zend_Form
 		$yearsofexp = new Zend_Form_Element_Text('years_exp');
 		$yearsofexp->setAttrib('maxLength', 10);
 		$yearsofexp->addFilter(new Zend_Filter_StringTrim());
-		$yearsofexp->addValidator("regex",true,array(
-						  'pattern'=>'/^[0-9]\d{0,1}(\.\d*)?$/', 
-                           'messages'=>array(
-                               'regexNotMatch'=>'Please enter only numbers.'
-                           )
-        	));
 			
 		$date_of_joining = new ZendX_JQuery_Form_Element_DatePicker('date_of_joining');
         $date_of_joining->setLabel("Date of Joining");


### PR DESCRIPTION
Remove client user id numeric validation (it was originally the field
years of experience)