### PR TITLE
Bump the version in the initial install.

### DIFF
--- a/install/hrms.sql
+++ b/install/hrms.sql
@@ -3093,7 +3093,7 @@ CREATE TABLE `main_patches_version` (
 
 /*Data for the table `main_patches_version` */
 
-insert  into `main_patches_version`(`id`,`version`,`createddate`,`modifieddate`,`isactive`) values (1,'3.1.1',NOW(),NOW(),1);
+insert  into `main_patches_version`(`id`,`version`,`createddate`,`modifieddate`,`isactive`) values (1,'3.2',NOW(),NOW(),1);
 
 /*Table structure for table `main_payfrequency` */
 


### PR DESCRIPTION
The database is compliant with 3.2 upstream, but thinks it is 3.1.1.
This causes the installer to request an unneeded upgrade package from
http://www.sentrifugo.com/services to attempt an upgrade.

Signed-Off-By: Rob Thomas <rthomas@sangoma.com>
Signed-Off-By: Rob Thomas <xrobau@gmail.com>