### PR TITLE
These ACL resources are duplicated.

### DIFF
--- a/application/modules/default/plugins/AccessControl.php
+++ b/application/modules/default/plugins/AccessControl.php
@@ -624,30 +624,6 @@ protected function _getAcl()
 		 $acl->addResource(new Zend_Acl_Resource('default:userloginlog'));
                     $acl->allow('admin', 'default:userloginlog', array('index','empnameauto','empidauto','empipaddressauto','empemailauto'));
 
-		 $acl->addResource(new Zend_Acl_Resource('default:addemployeeleaves'));
-                            $acl->allow('management', 'default:addemployeeleaves', array('index','add','edit','view','Add Employee Leave'));
-
-		 $acl->addResource(new Zend_Acl_Resource('default:announcements'));
-                            $acl->allow('management', 'default:announcements', array('index','getdepts','uploadsave','uploaddelete','add','edit','delete','view','Announcements'));
-
-		 $acl->addResource(new Zend_Acl_Resource('default:appraisalcategory'));
-                            $acl->allow('management', 'default:appraisalcategory', array('index','addpopup','getappraisalcategory','add','edit','delete','view','Parameters'));
-
-		 $acl->addResource(new Zend_Acl_Resource('default:appraisalhistoryself'));
-                            $acl->allow('management', 'default:appraisalhistoryself', array('index','view','My Appraisal History'));
-
-     $acl->addResource(new Zend_Acl_Resource('default:disciplinarymyincidents'));
-                    $acl->allow('admin', 'default:disciplinarymyincidents', array('index','view','edit','saveemployeeappeal','getdisciplinaryincidentpdf'));
-
-     $acl->addResource(new Zend_Acl_Resource('default:disciplinaryteamincidents'));
-                    $acl->allow('admin', 'default:disciplinaryteamincidents', array('index','view'));
-
-     $acl->addResource(new Zend_Acl_Resource('default:disciplinaryallincidents'));
-                    $acl->allow('admin', 'default:disciplinaryallincidents', array('index','view'));
-
-     $acl->addResource(new Zend_Acl_Resource('default:disciplinaryviolation'));
-                    $acl->allow('admin', 'default:disciplinaryviolation', array('index','add','view','edit','delete','addpopup'));
-
 	   }
 	   if($role == 2 )
            {


### PR DESCRIPTION
I'm not sure how this ever worked. I was unable to log in as an admin
user, as Zend was throwing an exception about these resources already
existing. 'default:addemployeleaves' was merged in e4fb891afb for
example. I suspect that a bad git merge caused these, as git blame
references 2.1 and 3.2 commits.

Signed-Off-By: Rob Thomas <rthomas@sangoma.com>
Signed-Off-By: Rob Thomas <xrobau@gmail.com>